### PR TITLE
Fix default props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export class Animate extends React.Component {
     this.animating = false;
   }
 
-  defaultProps = {
+  static defaultProps = {
     animate: true,
   };
 


### PR DESCRIPTION
Without this patch all instances default to *not*
animating, which is wrong. I am sorry!